### PR TITLE
Updated links and a bit of styling for Privacy Policy

### DIFF
--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="<link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cabin+Condensed&family=Shadows+Into+Light&display=swap" 
+    <link href="https://fonts.googleapis.com/css2?family=Cabin+Condensed&family=Shadows+Into+Light&display=swap"
     rel="stylesheet">
     <!--  -->
     <meta charset="UTF-8">
@@ -17,7 +17,7 @@
 </head>
 <body>
     <script id="replace_with_navbar" src="nav.js"></script>
-    
+
     <div id="toc-container">
         <div id="toc-list">
             <H3>Table of Contents</H3>
@@ -67,16 +67,16 @@
             <h1 class="section-title">Our Privacy Policy</h1>
             <div class="body">
                 <p>Your privacy is crucial.</p>
-                <p>At 2NatureDigital, accessible from 2NatureDigital,
+                <p>At 2NatureDigital, accessible from <a href="https://2naturedigital.com/">2NatureDigital</a>,
                     one of our main priorities is the privacy of our visitors. This
                     Privacy Policy document contains types of information that is
                     collected and recorded by 2NatureDigital and how we use it.
                 </p>
                 <p>
                     If you have additional questions or require more information
-                    about our Privacy Policy, do not hesitate to contact us.
+                    about our Privacy Policy, do not hesitate to <a href="mailto:2NatureDigital@gmail.com?subject=Regarding%20Rattler%20App&body=What%20would%20you%20like%20to%20contact%20us%20about%3F">contact us</a>.
                 </p>
-                
+
                 <p>
                     This Privacy Policy applies to our applications and our online
                     activities and is valid for users of our applications and visitors
@@ -90,30 +90,30 @@
         <div id="Consent">
             <h1 class="section-title">Consent:</h1>
             <div class="body">
-                <p>By using our applications or website, you hereby consent to our 
+                <p>By using our applications or website, you hereby consent to our
                     Privacy Policy and agree to its terms.</p>
             </div>
         </div>
         <div id="Information_we_collect">
             <h1 class="section-title">Information we collect:</h1>
             <div class="body">
-                <p>Currently, we collect no personal information. However, in the event 
+                <p>Currently, we collect no personal information. However, in the event
                     that we do:
                 </p>
                 <p>
-                    The personal information that you are asked to provide, and the 
-                    reasons why you are asked to provide it, will be made clear to 
+                    The personal information that you are asked to provide, and the
+                    reasons why you are asked to provide it, will be made clear to
                     you at the point we ask you to provide your personal information.
                 </p>
                 <p>
-                    If you contact us directly, we may receive additional information 
-                    about you such as your name, email address, phone number, the 
-                    contents of the message and/or attachments you may send us, and any 
+                    If you contact us directly, we may receive additional information
+                    about you such as your name, email address, phone number, the
+                    contents of the message and/or attachments you may send us, and any
                     other information you may choose to provide.
                 </p>
                 <p>
-                    When you register for an Account, we may ask for your contact 
-                    information, including items such as name, company name, address, 
+                    When you register for an Account, we may ask for your contact
+                    information, including items such as name, company name, address,
                     email address, and telephone number.
                 </p>
             </div>
@@ -129,9 +129,9 @@
                     <li>Improve, personalize, and expand our products</li>
                     <li>Understand and analyze how you use our products</li>
                     <li>Develop new products, services, features, and functionality</li>
-                    <li>Communicate with you, either directly or through one of our partners, 
-                        including for customer service, to provide you with updates and other 
-                        information relating to the website and app, and for marketing and 
+                    <li>Communicate with you, either directly or through one of our partners,
+                        including for customer service, to provide you with updates and other
+                        information relating to the website and app, and for marketing and
                         promotional purposes</li>
                     <li>Send you emails</li>
                     <li>Find and prevent fraud</li>
@@ -141,15 +141,15 @@
         <div id="Log_files">
             <h1 class="section-title">Log files</h1>
             <div class="body">
-                <p>2NatureDigital follows a standard procedure of using log files. 
-                    These files log users of our applications and visitors when they 
-                    visit websites. All hosting companies do this and a part of hosting 
-                    services' analytics. The information collected by log files include 
-                    internet protocol (IP) addresses, browser type, Internet Service 
-                    Provider (ISP), date and time stamp, referring/exit pages, and 
-                    possibly the number of clicks. These are not linked to any information 
-                    that is personally identifiable. The purpose of the information is 
-                    for analyzing trends, administering the site, tracking users' movement 
+                <p>2NatureDigital follows a standard procedure of using log files.
+                    These files log users of our applications and visitors when they
+                    visit websites. All hosting companies do this and a part of hosting
+                    services' analytics. The information collected by log files include
+                    internet protocol (IP) addresses, browser type, Internet Service
+                    Provider (ISP), date and time stamp, referring/exit pages, and
+                    possibly the number of clicks. These are not linked to any information
+                    that is personally identifiable. The purpose of the information is
+                    for analyzing trends, administering the site, tracking users' movement
                     on the website, and gathering demographic information.
                 </p>
             </div>
@@ -178,24 +178,24 @@
                     Note that 2NatureDigital has no access to or control over these
                     cookies that are used by third-party advertisers.
                 </p>
-            </div>            
+            </div>
         </div>
         <div id="Use_of_cookies_on_our_website">
             <h1 class="section-title">Use of cookies on our website</h1>
             <div class="body">
                 <p>
-                    Please be aware that our website, hosted by GoDaddy, uses 
-                    cookies for various purposes, including website traffic analysis 
+                    Please be aware that our website, hosted by GitHub, uses
+                    cookies for various purposes, including website traffic analysis
                     and user experience optimization.
                 </p>
                 <p>
-                    While 2NatureDigital does not directly control these cookies, 
+                    While 2NatureDigital does not directly control these cookies,
                     they may impact your experience on our site.
                 </p>
                 <p>
-                    By using our website, you acknowledge and consent to the use 
-                    of these cookies. For more detailed information about GoDaddy's 
-                    cookie usage and practices, please refer to GoDaddy's Privacy Policy.
+                    By using our website, you acknowledge and consent to the use
+                    of these cookies. For more detailed information about GitHub's
+                    cookie usage and practices, please refer to <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub's Privacy Policy</a>.
                 </p>
             </div>
         </div>
@@ -206,19 +206,19 @@
                     We currently do not use any third parties, but in the event that we do:
                 </p>
                 <p>
-                    2NatureDigital's Privacy Policy does not apply to other advertisers 
-                    or websites. Thus, we are advising you to consult the respective 
-                    Privacy Policies of these third-party ad servers for more detailed 
-                    information. It may include their practices and instructions about 
+                    2NatureDigital's Privacy Policy does not apply to other advertisers
+                    or websites. Thus, we are advising you to consult the respective
+                    Privacy Policies of these third-party ad servers for more detailed
+                    information. It may include their practices and instructions about
                     how to opt-out of certain options.
                 </p>
                 <p>
-                    You can choose to disable cookies through your individual browser 
-                    options. To know more detailed information about cookie management 
-                    with specific web browsers, it can be found at the browsers' respective 
+                    You can choose to disable cookies through your individual browser
+                    options. To know more detailed information about cookie management
+                    with specific web browsers, it can be found at the browsers' respective
                     websites.
                 </p>
-            </div>            
+            </div>
         </div>
         <div id="CCPA_privacy_rights">
             <h1 class="section-title">CCPA Privacy Rights</h1>
@@ -227,76 +227,76 @@
                     Under the CCPA, among other rights, California consumers have the right to:
                 </p>
                 <ul>
-                    <li>Request that a business that collects a consumer's personal data 
-                        disclose the categories and specific pieces of personal data that 
+                    <li>Request that a business that collects a consumer's personal data
+                        disclose the categories and specific pieces of personal data that
                         a business has collected about consumers.</li>
-                    <li>Request that a business delete any personal data about the consumer 
+                    <li>Request that a business delete any personal data about the consumer
                         that a business has collected.</li>
-                    <li>Request that a business that sells a consumer's personal data, not 
+                    <li>Request that a business that sells a consumer's personal data, not
                         sell the consumer's personal data.</li>
-                    <li>If you make a request, we have one month to respond to you. If you 
+                    <li>If you make a request, we have one month to respond to you. If you
                         would like to exercise any of these rights, please contact us.</li>
                 </ul>
-            </div>            
+            </div>
         </div>
         <div id="Global_data_protection_rights">
             <h1 class="section-title">Global Data Protection Rights</h1>
             <div class="body">
                 <p>
-                    We would like to make sure you are fully aware of 
+                    We would like to make sure you are fully aware of
                     all of your data protection rights. Every user is entitled to the following:
                 </p>
                 <ul>
-                    <li>The right to access – You have the right to request copies of your 
+                    <li>The right to access – You have the right to request copies of your
                         personal data. We may charge you a small fee for this service.</li>
-                    <li>The right to rectification – You have the right to request that we 
-                        correct any information you believe is inaccurate. You also have 
-                        the right to request that we complete the information you believe 
+                    <li>The right to rectification – You have the right to request that we
+                        correct any information you believe is inaccurate. You also have
+                        the right to request that we complete the information you believe
                         is incomplete.</li>
-                    <li>The right to erasure – You have the right to request that we erase 
+                    <li>The right to erasure – You have the right to request that we erase
                         your personal data, under certain conditions.</li>
-                    <li>The right to restrict processing – You have the right to request 
-                        that we restrict the processing of your personal data, under certain 
+                    <li>The right to restrict processing – You have the right to request
+                        that we restrict the processing of your personal data, under certain
                         conditions.</li>
-                    <li>The right to object to processing – You have the right to object to 
+                    <li>The right to object to processing – You have the right to object to
                         our processing of your personal data, under certain conditions.</li>
-                    <li>The right to data portability – You have the right to request that 
-                        we transfer the data that we have collected to another organization, 
+                    <li>The right to data portability – You have the right to request that
+                        we transfer the data that we have collected to another organization,
                         or directly to you, under certain conditions.</li>
-                    <li>If you make a request, we have one month to respond to you. If you 
+                    <li>If you make a request, we have one month to respond to you. If you
                         would like to exercise any of these rights, please contact us.</li>
                 </ul>
-            </div>            
+            </div>
         </div>
         <div id="Childrens_information">
             <h1 class="section-title">Children's Infomration</h1>
             <div class="body">
                 <p>
-                    Another part of our priority is adding protection for children while 
-                    using our applications as well as the internet. We encourage parents 
-                    and guardians to observe, participate in, and/or monitor and guide 
+                    Another part of our priority is adding protection for children while
+                    using our applications as well as the internet. We encourage parents
+                    and guardians to observe, participate in, and/or monitor and guide
                     their online activity.
                 </p>
                 <p>
-                    2NatureDigital does not knowingly collect any Personal Identifiable 
-                    Information from children under the age of 13. If you think that your 
-                    child provided this kind of information on our website, we strongly 
-                    encourage you to contact us immediately and we will do our best efforts 
+                    2NatureDigital does not knowingly collect any Personal Identifiable
+                    Information from children under the age of 13. If you think that your
+                    child provided this kind of information on our website, we strongly
+                    encourage you to contact us immediately and we will do our best efforts
                     to promptly remove such information from our records.
                 </p>
-            </div>            
+            </div>
         </div>
         <div id="Contact_information">
             <h1 class="section-title">Contact Information</h1>
             <div class="body">
                 <p>
-                    For any questions or concerns about our privacy practices, please contact 
-                    us at 2NatureDigital@gmail.com
+                    For any questions or concerns about our privacy practices, please contact
+                    us at <a href="mailto:2NatureDigital@gmail.com?subject=Regarding%20Rattler%20App&body=What%20would%20you%20like%20to%20contact%20us%20about%3F">2NatureDigital@gmail.com</a>
                 </p>
                 <p>
                     Learn more about us here
                 </p>
-            </div>            
+            </div>
         </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-/* TODO 
+/* TODO
 1. add dark/light theme toggle
 
 
@@ -34,14 +34,14 @@ body {
     font-family: "Shadows Into Light", cursive;
     font-weight: 400;
     font-style: normal;
-  } 
+  }
 
   .cabin-condensed-regular {
     font-family: "Cabin Condensed", sans-serif;
     font-weight: 400;
     font-style: normal;
   }
-  
+
 
 
 /* ----------- Navigation ------------ */
@@ -91,7 +91,7 @@ header .header-right nav a {
     justify-content: center;
     gap: 5rem;
     color: var(--fifthColor);
-    z-index: 999;    
+    z-index: 999;
 }
 
 /* hero image */
@@ -260,7 +260,7 @@ header .header-right nav a {
     margin-right: 2rem;
 }
 
-.resources h2 {    
+.resources h2 {
     margin: 1rem 0 2rem;
 }
 .resources ul {
@@ -278,6 +278,11 @@ header .header-right nav a {
     display: flex;
     flex-direction: row;
     gap: 1rem;
+}
+
+.resources img {
+    height: clamp(50px, 50vw, 10rem);
+    width: auto;
 }
 
 
@@ -301,13 +306,13 @@ header .header-right nav a {
     padding-top: 2rem;
 }
 
-#email-form, 
+#email-form,
 #message-form {
     padding-top: 1rem;
 }
 
 
-.form input, 
+.form input,
 .form textarea {
     background-color: rgb(238, 238, 238);
     padding: .5rem;
@@ -323,7 +328,7 @@ header .header-right nav a {
     opacity: .5;
 }
 
-.form input:focus, 
+.form input:focus,
 .form textarea:focus {
     outline: 2px solid var(--primaryColor);
 }


### PR DESCRIPTION
Closes #4 

The links were changed from GoDaddy's privacy policy to GitHub's.

Added `mailto:` links to the Contact Us portions and the emails.

Small change to the way the page shrinks and expands. 